### PR TITLE
Reduce test tolerance to avoid repeated test failure

### DIFF
--- a/tests/testthat/test-curvefit.R
+++ b/tests/testthat/test-curvefit.R
@@ -15,12 +15,12 @@ system.time(suppressWarnings(fit_cpp <- curvefit(y, t, tout = tout, methods, use
 test_that("curvefit works", {
     p1 = get_param(fit_cpp)[1:5]
     p2 = get_param(fit)[methods][1:5]
-    expect_true(all.equal(p1, p2, tolerance = 1e-6))
+    expect_true(all.equal(p1, p2, tolerance = 1e-5))
     expect_silent(r <- get_param(list(fit)))
 
     # For Klos, the result of C++ is slightly different from that of R version.
     diff = get_fitting(fit_cpp)$ziter2 - get_fitting(fit)$ziter2
-    expect_true(max(abs(diff)) <= 1e-6)
+    expect_true(max(abs(diff)) <= 1e-5)
     expect_silent(dfit <- get_param(list(fit)))
 })
 


### PR DESCRIPTION
Dear phenofit team,

During reverse-dependency tests for packages I look after (e.g. Rcpp and RcppArmadillo), package `phenofit` started to reliably fail just one test _on some systems_ but not others.  Sadly, one of the CRAN reference machines (administered by @kurthornik) is among those so this always triggers an email chain between CRAN and the corresponding maintainer.  On the last round I suggested to CRAN that 'we' should talk to you and they of course cleverly assigned me :)   I was able to reproduce this in a container (running `rocker/r2u:24.04` on an older i7-8700).   Switching the default tolerance from 1e-6 to 1e-5 in two instances overcomes this.

There is still remaining 'chatter' of the 'warning: solve(): system is singular; attempting approx solution' type that I also talked about with the author of Armadillo; his view was that this is likely due to your example / data and there is little he can do.  At least that does not lead to a FAIL.

Concerning the two-line change for the FAIL, you will know better if this has undesirable side effects.  It you see this as appropriate and could consider this in your next upload it might make overall operations a little smoother.  