### PR TITLE
Switch two badges from http to https

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,8 +15,8 @@ knitr::opts_chunk$set(
 # phenofit  
 [![R-CMD-check](https://github.com/eco-hydro/phenofit/workflows/R-CMD-check/badge.svg)](https://github.com/eco-hydro/phenofit/actions)
 [![codecov](https://codecov.io/gh/eco-hydro/phenofit/branch/master/graph/badge.svg)](https://app.codecov.io/gh/eco-hydro/phenofit)
-[![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
-[![CRAN](http://www.r-pkg.org/badges/version/phenofit)](https://cran.r-project.org/package=phenofit)
+[![License](https://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![CRAN](https://www.r-pkg.org/badges/version/phenofit)](https://cran.r-project.org/package=phenofit)
 [![total](https://cranlogs.r-pkg.org/badges/grand-total/phenofit)](https://cran.r-project.org/package=phenofit)
 [![monthly](https://cranlogs.r-pkg.org/badges/phenofit)](https://cran.r-project.org/package=phenofit)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5150204.svg)](https://doi.org/10.5281/zenodo.5150204)

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 
 [![R-CMD-check](https://github.com/eco-hydro/phenofit/workflows/R-CMD-check/badge.svg)](https://github.com/eco-hydro/phenofit/actions)
 [![codecov](https://codecov.io/gh/eco-hydro/phenofit/branch/master/graph/badge.svg)](https://app.codecov.io/gh/eco-hydro/phenofit)
-[![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
-[![CRAN](http://www.r-pkg.org/badges/version/phenofit)](https://cran.r-project.org/package=phenofit)
+[![License](https://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![CRAN](https://www.r-pkg.org/badges/version/phenofit)](https://cran.r-project.org/package=phenofit)
 [![total](https://cranlogs.r-pkg.org/badges/grand-total/phenofit)](https://cran.r-project.org/package=phenofit)
 [![monthly](https://cranlogs.r-pkg.org/badges/phenofit)](https://cran.r-project.org/package=phenofit)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6320537.svg)](https://doi.org/10.5281/zenodo.6320537)


### PR DESCRIPTION
While looking at what became #18 I noticed that one of your badges does not render at GitHub, and that it and another still use http URLs.  I had the same issue in a number of packages of mine, using https cures this.  This simple PR takes care of it.  Feel free to ignore it if you think it is too minor.