### PR TITLE
Fix for upcoming string 1.6.0 release

### DIFF
--- a/R/findpeaks.R
+++ b/R/findpeaks.R
@@ -147,7 +147,7 @@ findpeaks <- function (x, nups = 1, ndowns = nups, zero = "0", peakpat = NULL,
 #' @importFrom stringr str_replace_all
 str_replace_midzero <- function(x) {
     replace = function(x, replacement = "+") {
-        paste(rep(replacement, nchar(x)), collapse = "")
+        strrep(replacement, nchar(x))
     }
     str_replace_all(x, "\\++0\\++", . %>% replace("+")) %>%
         str_replace_all("-+0-+", . %>% replace("-"))


### PR DESCRIPTION
I couldn't get your package to compile so this is an educated guess. But `str_replace_all()` now requires a vectorised replacement function, since this is much more performant.